### PR TITLE
Set up development environment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
-verbosity=1
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Configured nosetests settings in setup.cfg for better test output.
- Added nosetests flags in setup.cfg
- Enabled colored test output and coverage
- Verified configuration with nosetests command
